### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We used different auto-update feed for `v0.10` and `v0.11`, so you won't see upd
 
 Install last release of v0.10 (0.10.7)
 
-`brew update && brew cask install https://raw.githubusercontent.com/caskroom/homebrew-cask/b6ac3795c1df9f97242481c0817b1165e3e6306a/Casks/react-native-debugger.rb`
+`brew update && brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/b6ac3795c1df9f97242481c0817b1165e3e6306a/Casks/react-native-debugger.rb`
 
 ## Documentation
 


### PR DESCRIPTION
Url structure of Homebrew's cask repo changed, breaking the listed URL.